### PR TITLE
直接粘贴网易云双语歌词 倍速播放 清空歌词 播放按钮文本图片随播放状态变化

### DIFF
--- a/Commands/EditCommands.cs
+++ b/Commands/EditCommands.cs
@@ -20,6 +20,12 @@ namespace Ruminoid.Trimmer.Commands
                 new KeyGesture(Key.F5, ModifierKeys.None, "F5")
             }));
 
+        public static RoutedUICommand ClearLyrics { get; } = new RoutedUICommand(
+            "清空歌词(_C)...",
+            "ClearLyrics",
+            typeof(UICommands),
+            new InputGestureCollection());
+
         public static RoutedUICommand EditSkipData { get; } = new RoutedUICommand(
             "编辑跳过单字(_E)",
             "EditSkipData",

--- a/Dialogs/EditLineDialog.xaml
+++ b/Dialogs/EditLineDialog.xaml
@@ -62,6 +62,7 @@
                 <RowDefinition/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <TextBlock Margin="0,0,0,12" Opacity="0.5">
                 <TextBlock.Style>
@@ -89,7 +90,11 @@
                     IsEnabled="False"
                     TypeList="{x:Static models:ModeType.PreType}"/>
             </Grid>
-            <StackPanel Grid.Row="3" Orientation="Horizontal"
+            <StackPanel Orientation="Horizontal" Grid.Row="3">
+                <TextBlock>双语：</TextBlock>
+                <CheckBox x:Name="Dual_languageSwitch"></CheckBox>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Orientation="Horizontal"
                         HorizontalAlignment="Right"
                         Margin="0,12,0,0">
                 <Button Margin="12,0" Content="确定" MinWidth="80"

--- a/Dialogs/EditLineDialog.xaml.cs
+++ b/Dialogs/EditLineDialog.xaml.cs
@@ -77,6 +77,10 @@ namespace Ruminoid.Trimmer.Dialogs
             _data = null;
             return data;
         }
+        public static bool GetIsDualLanguage()
+        {
+            return (bool)Current.Dual_languageSwitch.IsChecked;
+        }
 
         #endregion
 

--- a/Models/LrcModel.cs
+++ b/Models/LrcModel.cs
@@ -182,9 +182,19 @@ namespace Ruminoid.Trimmer.Models
 
         #region ItemOperations
 
-        public void AddLyrics(string lyrics)
+        public void AddLyrics(string lyrics, bool isDualLanguage = false)
         {
-            AddLyrics(lyrics.Split('\n'));
+            if(isDualLanguage)
+            {
+                AddLyrics(lyrics.Split('\n').Where((x, index) =>
+                {
+                    return index % 2 == 0;
+                }).ToArray());
+            }
+            else
+            {
+                AddLyrics(lyrics.Split('\n'));
+            }
         }
 
         public void AddLyrics(string[] lyrics)

--- a/Models/LrcModel.cs
+++ b/Models/LrcModel.cs
@@ -186,9 +186,10 @@ namespace Ruminoid.Trimmer.Models
         {
             if(isDualLanguage)
             {
-                AddLyrics(lyrics.Split('\n').Where((x, index) =>
+                lyrics = lyrics.Replace("\r", "");
+                AddLyrics(lyrics.Split('\n').Where(x => string.IsNullOrEmpty(x) is false).ToList().Where((x, index) =>
                 {
-                    return index % 2 == 0;
+                    return index % 2 == 0 ;
                 }).ToArray());
             }
             else
@@ -311,6 +312,11 @@ namespace Ruminoid.Trimmer.Models
             if (mIndex == -1) decreaseIndex = false;
             Current.Items.Remove(line);
             if (decreaseIndex) GlobalIndex -= oldCount;
+        }
+
+        public void ClearAll()
+        {
+            Current.Items.Clear();
         }
 
         #endregion

--- a/Views/LyricEditorViewCommandBinding.cs
+++ b/Views/LyricEditorViewCommandBinding.cs
@@ -22,6 +22,18 @@ namespace Ruminoid.Trimmer.Views
                 UICommands.AddLyrics,
                 AddLyrics_Executed,
                 CanExecute));
+            Application.Current.MainWindow?.CommandBindings.Add(new CommandBinding(
+                UICommands.ClearLyrics,
+                ClearLyrics_Executed,
+                CanExecute));
+        }
+
+        public void ClearLyrics_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            if(MessageBox.Show("确认清空所有歌词吗？", "确认", MessageBoxButton.OKCancel, MessageBoxImage.Question) == MessageBoxResult.OK)
+            {
+                LrcModel.Current.ClearAll();
+            }
         }
 
         public void AddLyrics_Executed(object sender, ExecutedRoutedEventArgs e)

--- a/Views/LyricEditorViewCommandBinding.cs
+++ b/Views/LyricEditorViewCommandBinding.cs
@@ -29,7 +29,7 @@ namespace Ruminoid.Trimmer.Views
             EditLineDialog.ShowAddDialog();
             string data = EditLineDialog.GetData();
             if (string.IsNullOrEmpty(data)) return;
-            LrcModel.Current.AddLyrics(data);
+            LrcModel.Current.AddLyrics(data, EditLineDialog.GetIsDualLanguage());
         }
 
         private void CanExecute(object sender, CanExecuteRoutedEventArgs e)

--- a/Views/PlaybackView.xaml.cs
+++ b/Views/PlaybackView.xaml.cs
@@ -30,7 +30,7 @@ namespace Ruminoid.Trimmer.Views
 
         public PlaybackView()
         {
-            InitializeComponent();
+            InitializeComponent();            
             VideoElement.PositionChanged += (o, args) =>
                 Position.Time = (long)args.Position.TotalMilliseconds;
             VideoElement.MediaOpened += (o, args) =>
@@ -38,11 +38,17 @@ namespace Ruminoid.Trimmer.Views
             VideoElement.MediaFailed += (o, args) => Console.WriteLine(@"[FFME] MediaFailed : " + args.ErrorException);
             VideoElement.MediaEnded += async (o, args) =>
             {
-                await VideoElement.Seek(TimeSpan.Zero);
-                await VideoElement.Play();
+                //await VideoElement.Seek(TimeSpan.Zero);
+                //await VideoElement.Play();
             };
             //VideoElement.RenderingVideo += RenderPreviewOnVideo;
             Position.OnPositionActiveChanged += () => SeekToPosition(Position.Time);
+            PlaySpeedChanged += PlaybackView_PlaySpeedChanged;
+        }
+
+        private void PlaybackView_PlaySpeedChanged(double speed)
+        {
+            VideoElement.SpeedRatio = speed;
         }
 
         private void RenderPreviewOnVideo(object sender, RenderingVideoEventArgs e)

--- a/Views/PlaybackViewCommandBinding.cs
+++ b/Views/PlaybackViewCommandBinding.cs
@@ -60,7 +60,7 @@ namespace Ruminoid.Trimmer.Views
             Playing = true;
             //MediaPlayer.Play(new Media(_libVLC, fileDialog.FileName));
             await VideoElement.Open(new Uri(fileDialog.FileName));
-            await VideoElement.Play();
+            //await VideoElement.Play();
         }
 
         private async void Command_UnloadMedia(object sender, ExecutedRoutedEventArgs e)

--- a/Views/PlaybackViewDataContext.cs
+++ b/Views/PlaybackViewDataContext.cs
@@ -27,7 +27,22 @@ namespace Ruminoid.Trimmer.Views
                 OnPropertyChanged();
             }
         }
+        private double _playSpeed = 1;
 
+        public double PlaySpeed
+        {
+            get => _playSpeed;
+            set
+            {
+                if (value > 3) value = 3;
+                if (value < 0.1) value = 0.1;
+                _playSpeed = value;
+                OnPropertyChanged();
+                PlaySpeedChanged?.Invoke(_playSpeed);
+            }
+        }
+        public delegate void PlaySpeedChangedHandler(double speed);
+        public event PlaySpeedChangedHandler PlaySpeedChanged;
         public Position Position { get; } = new Position();
 
         private bool _playing;
@@ -40,15 +55,42 @@ namespace Ruminoid.Trimmer.Views
                 if (!MediaLoaded) return;
                 _playing = value;
                 if (value)
+                {
                     VideoElement.Play();
+                    PlayButtonIconType = "Pause";
+                    PlayButtonText = "暂停";
+                }
                 else
+                {
                     VideoElement.Pause();
+                    PlayButtonIconType = "Run";
+                    PlayButtonText = "播放";
+                }
                 if (value) ThemeService.Current.ChangeAccent(Accent.Orange);
                 else ThemeService.Current.ChangeAccent(Accent.Blue);
                 OnPropertyChanged();
             }
         }
-
+        public string _playButtonIconType = "Run";
+        public string PlayButtonIconType
+        {
+            get => _playButtonIconType;
+            set
+            {
+                _playButtonIconType = value;
+                OnPropertyChanged();
+            }
+        }
+        public string _playButtonText = "播放";
+        public string PlayButtonText
+        {
+            get => _playButtonText;
+            set
+            {
+                _playButtonText = value;
+                OnPropertyChanged();
+            }
+        }
         #endregion
 
         #region PropertyChanged

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -72,6 +72,7 @@
                             </MenuItem>
                             <MenuItem Header="编辑(_E)">
                                 <MenuItem Command="{x:Static commands:UICommands.AddLyrics}" />
+                                <MenuItem Command="{x:Static commands:UICommands.ClearLyrics}" />
                                 <Separator/>
                                 <MenuItem Command="{x:Static commands:UICommands.EditSkipData}" />
                                 <MenuItem Command="{x:Static commands:UICommands.ReloadSkipData}" />

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -134,12 +134,31 @@
 
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition />
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="Auto" />
-                <ColumnDefinition />
+                <ColumnDefinition Width="2*"/>
             </Grid.ColumnDefinitions>
-
-            <StackPanel Grid.Column="1" HorizontalAlignment="Center" Orientation="Horizontal" Name="WndCaption"
+            <StackPanel x:Name="SpeedPanel" Orientation="Horizontal" VerticalAlignment="Center" Grid.Column="1" Margin="0,32,0,0">
+                <TextBlock VerticalAlignment="Center">倍速：</TextBlock>
+                <Slider                         
+                    ToolTip="E/P加速 Q/I减速"
+                    Width="100" 
+                    Minimum="0.1" 
+                    Maximum="3" 
+                    DataContext="{x:Static views:PlaybackView.Current}"
+                    Value="{Binding PlaySpeed}"
+                 ></Slider>
+                <TextBlock DataContext="{x:Static views:PlaybackView.Current}" VerticalAlignment="Center">
+                    <TextBlock.Text>
+                        <Binding Path="PlaySpeed" StringFormat="×{0:f2}"/>
+                    </TextBlock.Text>
+                </TextBlock>
+                <Button Margin="5,0,0,0" Name="ResetSpeed" Click="ResetSpeed_Click">
+                    重置
+                </Button>
+            </StackPanel>
+            <StackPanel Grid.Column="2" HorizontalAlignment="Center" Orientation="Horizontal" Name="WndCaption"
                         DataContext="{x:Static views:PlaybackView.Current}">
                 <Grid
                     Name="Wnd7"
@@ -246,10 +265,10 @@
                               Height="80" Width="80" Padding="0" Name="Wnd4"
                               IsEnabled="{Binding MediaLoaded}" IsChecked="{Binding Playing}">
                     <Grid Height="80" Width="80">
-                        <visualIcon:Icon Type="Run" Width="35" Height="35" Size="2"
+                        <visualIcon:Icon Type="{Binding PlayButtonIconType}" Width="35" Height="35" Size="2"
                                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="4,0" />
                         <TextBlock HorizontalAlignment="Center" VerticalAlignment="Bottom"
-                                   Margin="-2,0,0,6" Text="播放/暂停" />
+                                   Margin="-2,0,0,6" Text="{Binding PlayButtonText}" />
                     </Grid>
                 </ToggleButton>
                 <!--<ToggleButton HorizontalAlignment="Right" VerticalAlignment="Bottom"
@@ -263,7 +282,7 @@
                 </ToggleButton>-->
             </StackPanel>
 
-            <Grid Grid.Column="2" Margin="0,32,0,0">
+            <Grid Grid.Column="3" Margin="0,32,0,0">
                 <Slider Margin="12" Name="Wnd6"
                         DataContext="{x:Static views:PlaybackView.Current}"
                         Minimum="0" Maximum="1"

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -74,7 +74,7 @@ namespace Ruminoid.Trimmer.Windows
             IntPtr hwnd = new WindowInteropHelper(this).Handle;
             HwndSource.FromHwnd(hwnd).AddHook(WndProc);
             wndList = new List<FrameworkElement>
-                {Wnd1, Wnd2, Wnd3, Wnd4, Wnd5, Wnd6, Wnd7};
+                {Wnd1, Wnd2, Wnd3, Wnd4, Wnd5, Wnd6, Wnd7, SpeedPanel};
 
             PlaybackView.Current.DockControl.Show();
             if (!LayoutHelper<Config>.ApplyLayout(DockManager, this)) LyricEditorView.Current.DockControl.Show();
@@ -147,5 +147,10 @@ namespace Ruminoid.Trimmer.Windows
         private const int WM_NCHITTEST = 0x0084;
 
         #endregion
+
+        private void ResetSpeed_Click(object sender, RoutedEventArgs e)
+        {
+            PlaybackView.Current.PlaySpeed = 1.0;
+        }
     }
 }

--- a/Windows/MainWindowCommandBindings.cs
+++ b/Windows/MainWindowCommandBindings.cs
@@ -271,6 +271,15 @@ namespace Ruminoid.Trimmer.Windows
                 case Key.Right:
                     PlaybackView.Current.JumpDuration(+1000);
                     break;
+                case Key.Q:
+                case Key.I:
+                    PlaybackView.Current.PlaySpeed -= 0.1;
+                    break;
+                case Key.E:
+                case Key.P:
+                    PlaybackView.Current.PlaySpeed += 0.1;
+                    break;
+
             }
         }
 


### PR DESCRIPTION
- 网易云双语歌词为上中下译的格式 方便粘贴 自动过滤空行
- 增加倍速播放功能 0.1至3.0倍速 可通过Q/I减速 E/P加速 步长0.1
- 左上角菜单-编辑-清空歌词 可以快速清空歌词栏
- 播放主按钮原来只显示同一个图标/文本 添加更新

ps: 我认为
- 加载视频之后不应当自动播放（没找到改哪里）
- 在播放结束之后播放位置不应当回到开头并自动开始